### PR TITLE
Allow selector in 'inputs' option for daterange

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1503,7 +1503,7 @@
 					opts = $.extend({}, defaults, locopts, elopts, options);
 				if ($this.hasClass('input-daterange') || opts.inputs){
 					var ropts = {
-						inputs: opts.inputs || $this.find('input').toArray()
+						inputs: typeof(opts.inputs) !== 'string' ? opts.inputs : $this.find(opts.inputs || 'input').toArray()
 					};
 					$this.data('datepicker', (data = new DateRangePicker(this, $.extend(opts, ropts))));
 				}


### PR DESCRIPTION
Example

```
<div data-date-inputs=".datepicker" data-provide="datepicker">
    <input name=date_from class=datepicker> <input name="time_from">
    <input name=date_to class=datepicker> <input name="time_to">
<div>
```
